### PR TITLE
Longest timeout fix

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -127,7 +127,7 @@ namespace PingReporter
                         break;
                     }
 
-                    if (line.Contains("Request timed out"))
+                    if (line.Contains("Request timed out") || line.Contains("Destination host unreachable"))
                     {
                         PingEvent pingEvent = new PingEvent
                         {

--- a/Program.cs
+++ b/Program.cs
@@ -5,6 +5,12 @@ using System.IO;
 
 namespace PingReporter
 {
+    class PingEvent
+    {
+        public bool IsTimeout { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+
     class Program
     {
         static void GenerateReport(List<PingEvent> events, DateTime testStartTime, DateTime testEndTime)
@@ -23,8 +29,8 @@ namespace PingReporter
                 bool isPreviousResponse = false;
                 int timeoutCount = 0;
                 TimeSpan longestTimeoutPeriod = TimeSpan.Zero;
-                DateTime timeoutStart = DateTime.MinValue;
-                DateTime previousEventTime = DateTime.MinValue;
+                DateTime timeoutStart = DateTime.Now;
+                DateTime previousEventTime = DateTime.Now;
 
                 foreach (PingEvent pingEvent in events)
                 {
@@ -37,7 +43,7 @@ namespace PingReporter
                             isPreviousResponse = false;
                             timeoutCount++;
 
-                            if (timeoutStart == DateTime.MinValue)
+                            if (timeoutStart != pingEvent.Timestamp)
                             {
                                 timeoutStart = pingEvent.Timestamp;
                             }
@@ -58,7 +64,7 @@ namespace PingReporter
                                 longestTimeoutPeriod = timeoutPeriod;
                             }
 
-                            timeoutStart = DateTime.MinValue;
+                            // timeoutStart = DateTime.Now;
                         }
                     }
 
@@ -91,6 +97,7 @@ namespace PingReporter
 
             Console.Write("Enter the IP address to ping: ");
             string ipAddress = Console.ReadLine();
+            ipAddress = "192.168.50.154";
 
             string command = "ping " + ipAddress + " -t";
 

--- a/Program.cs
+++ b/Program.cs
@@ -5,12 +5,6 @@ using System.IO;
 
 namespace PingReporter
 {
-    class PingEvent
-    {
-        public bool IsTimeout { get; set; }
-        public DateTime Timestamp { get; set; }
-    }
-
     class Program
     {
         static void GenerateReport(List<PingEvent> events, DateTime testStartTime, DateTime testEndTime)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # Network Test
 ## Description
-	This program is meant to assist with testing how stable an internet connection is. The basis is simple, provide an IP Address to the console (ex. google is 8.8.8.8) and then run the program.
-	It will run a continuous ping of that IP Address for as long as you leave the program to be running. Once you end the program, it will provide a report containing every instance of pings timing out, and they times those time outs started.
+This program is meant to assist with testing how stable an internet connection is. The basis is simple, provide an IP Address to the console (ex. google is 8.8.8.8) and then run the program.
+It will run a continuous ping of that IP Address for as long as you leave the program to be running. Once you end the program, it will provide a report containing every instance of pings timing out, and they times those time outs started.
 
 ## Known Bugs
-	Currently, the line for "Longest Timeout Period:" is wonky. Even if you do not have any pings time out, it will still show a time. In addition, the times are always wrong.
-	For example, if I had a ping time out at 14:29:56, and then a ping is sucessfull immediately after that at 14:30:06, then we had a time out duration of roughly half a second
-	However, the report would show a difference of several hours rather than less than a second.
-	> Researching Fix
+Currently, the line for "Longest Timeout Period:" is wonky. Even if you do not have any pings time out, it will still show a time. In addition, the times are always wrong.	For example, if I had a ping time out at 14:29:56, and then a ping is sucessfull immediately after that at 14:30:06, then we had a time out duration of roughly half a second. However, the report would show a difference of several hours rather than less than a second.
+	> -Researching Fix-
+	I believe I have the fix for this inplemented, however I discovered that I am not accounting for other events in which pings are not returning, such as "Destination Host Unreachable"
 
 ## To-Do
-	Fix the bug with the Longest Timeout Period
-	Rework how the dropped pings show in the report
-		- Research maybe only showing the longest ping time out duration times?
-	Look into adding a timer set by user to let the program be automated
-	Look into additional data that may be useful in the report
-	Add code for user to name the report
+-Fix the bug with the Longest Timeout Period-
+Rework how the dropped pings show in the report
+	- Research maybe only showing the longest ping time out duration times?
+Look into adding a timer set by user to let the program be automated
+Look into additional data that may be useful in the report
+Add code for user to name the report


### PR DESCRIPTION
Fixed the issue where the Longest Timem Out portion of the report was giving wildly inaccurate data. Data now reflects correctly.